### PR TITLE
List Fractal as dependencies not devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "build": "gulp build",
     "deploy": "gulp deploy"
   },
-  "devDependencies": {
+  "dependencies": {
     "@frctl/fractal": "latest",
-    "@frctl/nunjucks-adapter": "latest",
+    "@frctl/nunjucks-adapter": "latest"
+  },
+  "devDependencies": {
     "del": "latest",
     "gulp": "latest",
     "gulp-autoprefixer": "latest",


### PR DESCRIPTION
They are hard dependencies for running the repo so should be listed as deps, not devDeps.

(also breaks my little app when they are listed as devDeps :-))